### PR TITLE
Fix and Test for streamHandler

### DIFF
--- a/src/Domain/Socket/StreamHandler.php
+++ b/src/Domain/Socket/StreamHandler.php
@@ -78,7 +78,7 @@ class StreamHandler
                 }
 
                 if($dataLength > $messageLength) {
-                    $this->currentMessage = substr($data, $messageLength + 1, $dataLength);
+                    $this->currentMessage = substr($data, $messageLength, $dataLength);
 
                     return $this->decomposeMessage(substr($data, 0, $messageLength));
                 }


### PR DESCRIPTION
This is a fix (and test) for how streamHandler handles data that contains multiple messages. It fixes issue #4 . When data comes in StreamHandler's handle method, the code checks if the data contains more than one message. If it does, it will split the data and store any subsequent data in an instance variable for later use. This pull request fixes the starting position of the subsequent data. 
