### PR TITLE
refactor of StreamHandler and EventStore client

### DIFF
--- a/src/Application/Api/EventStore.php
+++ b/src/Application/Api/EventStore.php
@@ -76,15 +76,19 @@ class EventStore
 
         $this->stream->onData(function($data) use($streamHandler, $actionsToRun) {
 
-            $socketMessage = $streamHandler->handle($data);
-            if(is_null($socketMessage)) {
+            $socketMessages = $streamHandler->handle($data);
+
+            if(sizeof($socketMessages) == 0) {
                 return;
             }
-            foreach ($actionsToRun as $key => $callback) {
-               if ($key === $socketMessage->getMessageType()->getType()) {
+            /** @var SocketMessage $socketMessage */
+            foreach ($socketMessages as $socketMessage) {
+                $messageType = $socketMessage->getMessageType()->getType();
+                if (array_key_exists($messageType, $actionsToRun)) {
+                    $callback = $actionsToRun[$messageType];
                     $callback($socketMessage);
-                    return;
-               }
+                }
+
             }
         });
     }


### PR DESCRIPTION
This pull request is to fix an issue when a data stream contains multiple complete messages. The handle method will now return an array of SocketMessages instead of just 1. The EventStore client has also been changed to handle the multiple messages. 

If the last part of the data stream contain a partial message, this will be kept in the instance variable as before. 

A test has been added to test this new scenario and previous test have been updated to expect the array of socketMessages. 
